### PR TITLE
Fix area products and add text wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # picometar
 Micropython METAR Aviation Weather Checker
 
-This is a small app created for viewing aviation weather with a Pi Pico W and a Pimoroni Pico Display. A top menu lets you pick between METARs, TAFs and other text products from NOAA. Use the **X** and **Y** buttons to scroll through long text products.
+This is a small app created for viewing aviation weather with a Pi Pico W and a Pimoroni Pico Display. A top menu lets you pick between METARs, TAFs and other text products from NOAA. Use the **X** and **Y** buttons to scroll through long text products. Long lines are wrapped automatically so information doesn't overlap on the display.
 
-Some of the area weather products on NOAA's server don't allow HTTPS requests, so the app fetches them over plain HTTP.
-This is a small app created for viewing aviation weather with a Pi Pico W and a Pimoroni Pico Display. A top menu lets you pick between METARs, TAFs and other text products from NOAA.
+Some of the area weather products on NOAA's server require HTTPS while others only allow plain HTTP. The app now uses whichever protocol works for each feed.
 
 First go ahead and set up the Pico W and the Pico Display - instructions for that are at the Pimoroni GitHub for the Pico Display.  I used I think their Rainbow Unicorn 1.22 or so for the UFW on the Pico W.  It includes the display libraries used by this code.
 

--- a/pico_version.py
+++ b/pico_version.py
@@ -82,11 +82,13 @@ weather_products = {
     },
     "SIGMET": {
         "needs_station": False,
-        "url": "http://tgftp.nws.noaa.gov/data/sigmets/sigmets.txt",
+        # Using HTTPS here avoids occasional 403 errors
+        "url": "https://tgftp.nws.noaa.gov/data/sigmets/sigmets.txt",
     },
     "PIREP": {
         "needs_station": False,
-        "url": "http://tgftp.nws.noaa.gov/data/aircraftreports/pireps.txt",
+        # Using HTTPS here avoids occasional 403 errors
+        "url": "https://tgftp.nws.noaa.gov/data/aircraftreports/pireps.txt",
     },
 }
 
@@ -329,7 +331,24 @@ def enter_airport():
 
         time.sleep(0.1)
 
+
     return ''.join(airport_code)
+
+def wrap_text(text, char_width, max_width):
+    """Word-wrap text for a fixed-width font."""
+    words = text.split(" ")
+    lines = []
+    current = ""
+    for word in words:
+        if len(current) + len(word) + (1 if current else 0) > max_width // char_width:
+            lines.append(current)
+            current = word
+        else:
+            if current:
+                current += " "
+            current += word
+    lines.append(current)
+    return lines
 
 def fetch_weather_data(product, station=None, max_retries=3):
     """Fetch text data for the given weather product."""
@@ -392,9 +411,13 @@ def display_weather(product, station=None):
 
         if data:
             full_text = current_utc + '\n' + data
-            lines = full_text.split('\n')
         else:
-            lines = [f"Error fetching {product}"]
+            full_text = f"Error fetching {product}"
+
+        # Wrap each line so it fits the display width
+        lines = []
+        for raw in full_text.split('\n'):
+            lines.extend(wrap_text(raw, 8 * 2, WIDTH))
 
         line_height = 16  # bitmap8 at scale 2 is ~16px tall
         lines_per_screen = HEIGHT // line_height


### PR DESCRIPTION
## Summary
- fetch SIGMET and PIREP using HTTPS
- wrap long lines in Pico display output so they no longer overlap
- document protocol use and line wrapping in README

## Testing
- `python3 -m py_compile pico_version.py cardputer_version.py metar_dev_cp.py wifi_config.py`