### PR TITLE
Add ISIGMET feed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ Micropython METAR Aviation Weather Checker
 
 This is a small app created for viewing aviation weather with a Pi Pico W and a Pimoroni Pico Display. A top menu lets you pick between METARs, TAFs and other text products from NOAA. Use the **X** and **Y** buttons to scroll through long text products. Long lines are wrapped automatically so information doesn't overlap on the display.
 
+The "ISIGMET" option pulls international SIGMETs from AviationWeather.gov. The
+feed is requested using a bounding box over the United States to keep the
+download size small. SIGMET pages are separated by dashed lines, and any entry
+with an identifier beginning with `K` is shown first. Scroll with **X** and
+**Y** to move within a SIGMET and advance to the next or previous report when
+reaching the end.
+
 Some of the area weather products on NOAA's server require HTTPS while others only allow plain HTTP. The app now uses whichever protocol works for each feed.
 
 First go ahead and set up the Pico W and the Pico Display - instructions for that are at the Pimoroni GitHub for the Pico Display.  I used I think their Rainbow Unicorn 1.22 or so for the UFW on the Pico W.  It includes the display libraries used by this code.

--- a/pico_version.py
+++ b/pico_version.py
@@ -90,6 +90,15 @@ weather_products = {
         # Using HTTPS here avoids occasional 403 errors
         "url": "https://tgftp.nws.noaa.gov/data/aircraftreports/pireps.txt",
     },
+    "ISIGMET": {
+        "needs_station": False,
+        # International SIGMET feed from AviationWeather.gov limited
+        # to a U.S. bounding box to keep downloads small
+        "url": (
+            "https://aviationweather.gov/api/data/isigmet"
+            "?format=text&bbox=-135,20,-60,55"
+        ),
+    },
 }
 
 def connect_to_wifi():
@@ -349,6 +358,28 @@ def wrap_text(text, char_width, max_width):
     lines.append(current)
     return lines
 
+def parse_isigmet(raw_text):
+    """Split ISIGMET data into pages and reorder US pages first."""
+    import re
+
+    pages = [p.strip() for p in raw_text.split("----------------------") if p.strip()]
+
+    def has_us_identifier(text):
+        return re.search(r"\bK[A-Z]{3}\b", text) is not None
+
+    us_pages = [p for p in pages if has_us_identifier(p)]
+    other_pages = [p for p in pages if not has_us_identifier(p)]
+    ordered_pages = us_pages + other_pages
+
+    # Split each page into wrapped lines
+    wrapped_pages = []
+    for page in ordered_pages:
+        lines = []
+        for raw in page.split("\n"):
+            lines.extend(wrap_text(raw, CHAR_WIDTH * TEXT_SCALE, WIDTH))
+        wrapped_pages.append(lines)
+    return wrapped_pages
+
 def fetch_weather_data(product, station=None, max_retries=3):
     """Fetch text data for the given weather product."""
     info = weather_products.get(product)
@@ -390,6 +421,8 @@ def display_weather(product, station=None):
     last_update = time.ticks_ms()
     last_ntp_update = time.ticks_ms()
     scroll = 0
+    page_index = 0
+    pages = None
 
     while True:
         current_time = time.ticks_ms()
@@ -406,22 +439,26 @@ def display_weather(product, station=None):
             set_rtc_from_ntp()
             last_ntp_update = current_time
 
-        # Prepare text lines for display
         current_utc = get_current_utc()
         display.set_pen(BLACK)
         display.clear()
         display.set_pen(WHITE)
         display.set_font("bitmap8")
 
-        if data:
-            full_text = current_utc + '\n' + data
+        if product == "ISIGMET" and data:
+            if pages is None:
+                pages = parse_isigmet(data)
+            if page_index >= len(pages):
+                page_index = len(pages) - 1
+            lines = pages[page_index]
         else:
-            full_text = f"Error fetching {product}"
-
-        # Wrap each line so it fits the display width
-        lines = []
-        for raw in full_text.split('\n'):
-            lines.extend(wrap_text(raw, CHAR_WIDTH * TEXT_SCALE, WIDTH))
+            if data:
+                full_text = current_utc + '\n' + data
+            else:
+                full_text = f"Error fetching {product}"
+            lines = []
+            for raw in full_text.split('\n'):
+                lines.extend(wrap_text(raw, CHAR_WIDTH * TEXT_SCALE, WIDTH))
 
         line_height = LINE_HEIGHT
         lines_per_screen = HEIGHT // line_height
@@ -436,10 +473,18 @@ def display_weather(product, station=None):
         display.update()
 
         if button_x.read():
-            scroll = max(0, scroll - 1)
+            if scroll > 0:
+                scroll = max(0, scroll - 1)
+            elif product == "ISIGMET" and pages and page_index > 0:
+                page_index -= 1
+                scroll = 0
         elif button_y.read():
             if scroll + lines_per_screen < len(lines):
                 scroll += 1
+            else:
+                if product == "ISIGMET" and pages and page_index + 1 < len(pages):
+                    page_index += 1
+                    scroll = 0
         elif button_b.read():
             break
 


### PR DESCRIPTION
## Summary
- add `ISIGMET` product to weather feeds
- parse new feed pages and reorder U.S. SIGMETs first
- handle scrolling across SIGMET pages in `display_weather`
- request ISIGMET data using a U.S. bounding box to keep downloads small
- document new product in README

## Testing
- `python -m py_compile pico_version.py cardputer_version.py wifi_config.py`